### PR TITLE
✨ feat(restaurant/member): implement member APIs (getMemberMenu, delivery-confirmation)

### DIFF
--- a/backend/src/restaurant/member/Type/food-room-member-response.type.ts
+++ b/backend/src/restaurant/member/Type/food-room-member-response.type.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+
+class MyOrderItemType {
+  itemName: string;
+  quantity: number;
+  price: number;
+}
+
+export class FoodRoomMemberResponseType {
+  foodJoinUserId: number;
+  restaurantName: string;
+  deadline: string;
+  deliveryFee: number;
+  memberCount: number;
+  @Type(() => MyOrderItemType)
+  myOrderItems: MyOrderItemType[];
+}

--- a/backend/src/restaurant/member/member.controller.ts
+++ b/backend/src/restaurant/member/member.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Patch } from '@nestjs/common';
 import { MemberService } from './member.service';
 
 @Controller('restaurant/member')
@@ -11,6 +11,14 @@ export class MemberController {
     return {
       message: `${roomId}방에서 내가 시킨 메뉴`,
       data: result
+    };
+  }
+
+  @Patch('delivery-confirmation/:id')
+  async patch2Delivery(@Param('id') id: string) {
+    await this.memberService.patch2Delivery(id)
+    return {
+      message: `foodJoinUser ${id}번 방에서 delivery_confirmation 1로 변경`,
     };
   }
 }

--- a/backend/src/restaurant/member/member.controller.ts
+++ b/backend/src/restaurant/member/member.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { MemberService } from './member.service';
+
+@Controller('restaurant/member')
+export class MemberController {
+  constructor(private readonly memberService: MemberService) {}
+
+  @Get('/:roomId/:userId')
+  async getMemberMenu(@Param('userId') userId: string, @Param('roomId') roomId: string) {
+    const result = await this.memberService.getMemberMenu(+userId, +roomId)
+    return {
+      message: `${roomId}방에서 내가 시킨 메뉴`,
+      data: result
+    };
+  }
+}

--- a/backend/src/restaurant/member/member.service.ts
+++ b/backend/src/restaurant/member/member.service.ts
@@ -38,4 +38,17 @@ export class MemberService {
         }
     }
 
+    async patch2Delivery(id: string): Promise<void> {
+        const foodJoinUser = await this.foodJoinUserRepo.findOne({
+            where: {id: +id},
+        })
+
+        if(!foodJoinUser) {
+            throw new NotFoundException(`foodJoinUser에 ${id}번 방이 존재하지 않음`)
+        }
+
+        foodJoinUser.deliveryConfirmation = 1;
+
+        await this.foodJoinUserRepo.save(foodJoinUser)
+    }
 }

--- a/backend/src/restaurant/member/member.service.ts
+++ b/backend/src/restaurant/member/member.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FoodJoinUser } from '../entities/food-join-user.entity';
+import { Repository } from 'typeorm';
+import { FoodRoomMemberResponseType } from './Type/food-room-member-response.type';
+
+@Injectable()
+export class MemberService {
+  constructor(
+    @InjectRepository(FoodJoinUser)
+    private readonly foodJoinUserRepo: Repository<FoodJoinUser>,
+  ) {}
+
+  async getMemberMenu(userId: number, roomId: number): Promise<FoodRoomMemberResponseType> {
+        const foodRoomMember = await this.foodJoinUserRepo.findOne({
+            where: {
+                foodFareRoom: { id: roomId },
+                user: { id: userId }
+            },
+            relations: ['user', 'foodFareRoom', 'foodFareRoom.restaurant', 'foodFareRoom.foodJoinUsers', 'foodOrders', 'foodOrders.foodItem']
+        })
+        
+        if (!foodRoomMember) {
+          throw new NotFoundException(`Member not found for userId=${userId}, roomId=${roomId}`);
+        }
+
+        return {
+              foodJoinUserId: foodRoomMember.user.id,
+              restaurantName: foodRoomMember.foodFareRoom.restaurant.restaurantName,
+              deadline: foodRoomMember.foodFareRoom.deadline.toString(),
+              deliveryFee: foodRoomMember.foodFareRoom.restaurant.deliveryFee,
+              memberCount: foodRoomMember.foodFareRoom.foodJoinUsers.length,
+              myOrderItems: foodRoomMember.foodOrders.map((order) => ({
+                itemName: order.foodItem.itemName,
+                quantity: order.quantity,
+                price: order.foodItem.price
+              }))
+        }
+    }
+
+}

--- a/backend/src/restaurant/restaurant.module.ts
+++ b/backend/src/restaurant/restaurant.module.ts
@@ -8,10 +8,12 @@ import { FoodResult } from './entities/food-result.entity';
 import { FoodJoinUser } from './entities/food-join-user.entity';
 import { LeaderController } from './leader/leader.controller';
 import { LeaderService } from './leader/leader.service';
+import { MemberController } from './member/member.controller';
+import { MemberService } from './member/member.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Restaurant, FoodFareRoom, FoodResult, FoodJoinUser,])],
-  controllers: [RestaurantController, LeaderController],
-  providers: [RestaurantService, LeaderService],
+  controllers: [RestaurantController, LeaderController, MemberController],
+  providers: [RestaurantService, LeaderService, MemberService],
 })
 export class RestaurantModule {}


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

- 멤버가 특정 방에서 본인이 주문한 메뉴를 확인할 수 있는 getMemberMenu API를 추가함.

- 주문 배송 확인 상태를 변경하는 delivery-confirmation PATCH API를 추가함.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

- MemberController / MemberService 추가
  - GET /restaurant/member/:roomId/:userId : 사용자의 방 내 주문 조회 
  - PATCH /restaurant/member/delivery-confirmation/:id : foodJoinUser의 deliveryConfirmation을 1로 변경

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

- 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

- 없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

- 없음

## 📚 관련된 Issue나 Notion, 문서

- 없음

## 🖥 작동하는 모습

<img width="2580" height="1391" alt="image" src="https://github.com/user-attachments/assets/1ddd15e8-3aaa-46e9-a39b-3430d74063f2" />
