### PR TITLE
✨ feat(authz): enforce creator-only access and progress updates

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -20,5 +20,5 @@ export class AuthController {
   @ApiBearerAuth('access-token')
   getMe(@Req() req) {
   return req.user; // DB 조회 필요 없으면 이 정도로 충분
-}
+  }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -19,18 +19,13 @@ export class AuthService {
   async userAuth(dto: LoginDto) {
   const user = await this.userRepo
     .createQueryBuilder('u')
-    .addSelect('u.password') // select:false여도 강제 포함
+    .addSelect('u.password')
     .where('u.email = :email', { email: dto.email })
     .getOne();
 
-  console.log('DBG user.password =>', user?.password);
-  console.log('DBG user.password length =>', user?.password?.length);
-
   if (!user) throw new UnauthorizedException('Invalid credentials');
 
-  console.log('DBG dto.password =>', JSON.stringify(dto.password));
   const cmp = await bcrypt.compare(dto.password, user.password);
-  console.log('DBG compare(dto vs hash) =>', cmp);
 
   if (!cmp) throw new UnauthorizedException('Invalid credentials');
   return user;
@@ -38,7 +33,11 @@ export class AuthService {
 
   
   async login(user: User){
-    const payload = { sub: user.email, userStuNum: user.studentNumber }
+    const payload = { 
+      sub: user.id, 
+      email: user.email, 
+      userStuNum: user.studentNumber 
+    };
 
     const accessToken = this.jwtService.sign(payload);
 

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -4,7 +4,8 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 
 type JwtPayload = {
-  sub: string;
+  sub: number;
+  email: string;
   userStuNum: number;
   iat?: number;
   exp?: number;
@@ -28,6 +29,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: JwtPayload) {
     return {
+      id: payload.sub, 
       email: payload.sub,
       userStuNum: payload.userStuNum,
     };

--- a/backend/src/common/types/express.d.ts
+++ b/backend/src/common/types/express.d.ts
@@ -1,0 +1,7 @@
+import { User } from "src/user/entities/user.entity";
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    user: { id: number; email: string; userStuNum: number; };
+  }
+}

--- a/backend/src/restaurant/leader/leader.controller.ts
+++ b/backend/src/restaurant/leader/leader.controller.ts
@@ -1,13 +1,18 @@
-import { Controller, Get, Param, Patch } from '@nestjs/common';
+import { Controller, Get, Param, Patch, Req, UseGuards } from '@nestjs/common';
 import { LeaderService } from './leader.service';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { Request } from 'express';
+import { ApiBearerAuth } from '@nestjs/swagger';
 
 @Controller('restaurant/leader')
 export class LeaderController {
   constructor(private readonly leaderService: LeaderService) {}
-
+  
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
   @Get(':id')
-  async getLeaderFoodFareRoom(@Param('id') id: string) {
-    const result = await this.leaderService.getLeaderFoodFareRoom(id);
+  async getLeaderFoodFareRoom(@Param('id') id: string, @Req() req: Request) {
+    const result = await this.leaderService.getLeaderFoodFareRoom(id, req.user.id);
 
     return {
       message: `${id}방장 방 정보`,
@@ -15,18 +20,22 @@ export class LeaderController {
     };
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
   @Patch('update-progress/:id')
-  async patch3Progress(@Param('id') id: string) {
-    await this.leaderService.patch3Progress(id)
+  async patch3Progress(@Param('id') id: string, @Req() req: Request) {
+    await this.leaderService.patch3Progress(id, req.user.id)
 
     return {
       message: `foodFareRoom ID ${id}번 방에서 progress 3으로 변경`,
     };
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
   @Patch('break-up/:id')
-  async patch4progress(@Param('id') id: string) {
-    await this.leaderService.patch4Progress(id)
+  async patch4progress(@Param('id') id: string, @Req() req: Request) {
+    await this.leaderService.patch4Progress(id, req.user.id)
 
     return {
       message: `foodFareRoom ID ${id}방에서 progress 4로 변경`,

--- a/backend/src/restaurant/member/member.controller.ts
+++ b/backend/src/restaurant/member/member.controller.ts
@@ -5,6 +5,7 @@ import { MemberService } from './member.service';
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
 
+  
   @Get('/:roomId/:userId')
   async getMemberMenu(@Param('userId') userId: string, @Param('roomId') roomId: string) {
     const result = await this.memberService.getMemberMenu(+userId, +roomId)

--- a/backend/src/restaurant/restaurant.controller.ts
+++ b/backend/src/restaurant/restaurant.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Post, Body, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, Get, Param, UseGuards, Req } from '@nestjs/common';
 import { RestaurantService } from './restaurant.service';
 import { FoodFareRoomDto } from './dto/create-food-fare-room.dto';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { Request } from 'express';
 
 @Controller('restaurant')
 export class RestaurantController {
@@ -9,9 +10,8 @@ export class RestaurantController {
 
   @UseGuards(JwtAuthGuard)
   @Post('food-fare-room')
-  async createFoodFareRoom(@Body() dto: FoodFareRoomDto) {
-    // 자기 자신의 id를 세션으로 처리하면 body에 자기자신의 id는 안보내도됨. 현재는 body에 넣어서 설계.
-    return await this.restaurantService.createFoodFareRoom(dto);
+  async createFoodFareRoom(@Body() dto: FoodFareRoomDto, @Req() req: Request) {
+    return await this.restaurantService.createFoodFareRoom(dto, req.user.id);
   }
 
   @Get('current-rooms')

--- a/backend/src/restaurant/restaurant.service.ts
+++ b/backend/src/restaurant/restaurant.service.ts
@@ -19,10 +19,10 @@ export class RestaurantService {
     @InjectRepository(Restaurant) private readonly restaurantRepo: Repository<Restaurant>,
   ) {}
 
-  async createFoodFareRoom(dto: FoodFareRoomDto) {
+  async createFoodFareRoom(dto: FoodFareRoomDto, userId: number): Promise<FoodFareRoom> {
     const room = this.foodFareRoomRepo.create({
       restaurant: { id: dto.restaurantId },
-      creatorUser: { id: dto.userId },
+      creatorUser: { id: userId },
       deadline: new Date(dto.deadline),
       minMember: dto.minMember,
     });
@@ -36,7 +36,7 @@ export class RestaurantService {
     await this.foodResultRepo.save(foodResult);
 
     const foodJoinUser = this.foodJoinUserRepo.create({
-      user: { id: dto.userId },
+      user: { id: userId },
       foodFareRoom: savedRoom,
       deliveryConfirmation: 0,
       foodOrders: [],


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

- 단순 인증(JWT 로그인 여부 확인)만으로는 충분하지 않음
- 방 생성자만 접근하거나 상태 변경이 가능하도록 인가(authorization) 로직을 추가

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

- GET /restaurant/leader/:id 요청 시 방 생성자만 조회 가능하도록 검증 추가
- patch3Progress, patch4Progress API에 생성자 권한 검증 추가
- JwtStrategy에서 req.user 타입 확장 (id, email, userStuNum)
- express.d.ts를 통해 Request 타입 선언 보강
- Controller 레벨에서 @UseGuards(JwtAuthGuard) 적용 및 req.user.id 전달하도록 수정

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

- RestaurantService.createFoodFareRoom 수정 → DTO에서 userId를 받지 않고, 인증된 사용자 ID(req.user.id)를 사용하도록 개선

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

- 없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

- 없음

## 📚 관련된 Issue나 Notion, 문서

- 없음

## 🖥 작동하는 모습

- 없음
