### PR TITLE
📖 docs(swagger): apply Bearer auth to POST endpoint and enrich descriptions

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/serve-static": "^5.0.3",
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/typeorm": "^11.0.0",
         "bcrypt": "^6.0.0",
@@ -2686,6 +2687,33 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.2"
+      }
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-5.0.3.tgz",
+      "integrity": "sha512-0jFjTlSVSLrI+mot8lfm+h2laXtKzCvgsVStv9T1ZBZTDwS26gM5czIhIESmWAod0PfrbCDFiu9C1MglObL8VA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-to-regexp": "8.2.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.4",
+        "@nestjs/common": "^11.0.2",
+        "@nestjs/core": "^11.0.2",
+        "express": "^5.0.1",
+        "fastify": "^5.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/swagger": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/serve-static": "^5.0.3",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,9 +1,12 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { IsEmail, IsString } from "class-validator";
 
 export class LoginDto {
+    @ApiProperty({ type: String, description: '이메일 형식', required: true, example: 'alice@example.com' })
     @IsEmail()
     email: string;
 
+    @ApiProperty({ type: String, description: '비밀번호', required: true, example: 'abc123' })
     @IsString()
     password: string;
 }

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -30,7 +30,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: JwtPayload) {
     return {
       id: payload.sub, 
-      email: payload.sub,
+      email: payload.email,
       userStuNum: payload.userStuNum,
     };
   }

--- a/backend/src/restaurant/dto/create-food-fare-room.dto.ts
+++ b/backend/src/restaurant/dto/create-food-fare-room.dto.ts
@@ -1,15 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsISO8601 } from 'class-validator';
 
 export class FoodFareRoomDto {
+  @ApiProperty({ type: Number, description: '식당 번호', required: true, example: 1 })
   @IsInt()
   restaurantId: number;
 
+  @ApiProperty({ type: Number, description: '주문을 시작하기 위해 필요한 최소 인원', required: true, example: 4 })
   @IsInt()
   minMember: number;
 
+  @ApiProperty({ type: String, description: '방의 마감기한 (ISO8601 형식)', required: true, example: '2024-09-20T20:00:00Z' })
   @IsISO8601()
   deadline: string;
-
-  @IsInt()
-  userId: number;
 }

--- a/backend/src/restaurant/leader/leader.controller.ts
+++ b/backend/src/restaurant/leader/leader.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Param, Patch, Req, UseGuards } from '@nestjs/common';
 import { LeaderService } from './leader.service';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { Request } from 'express';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 
 @Controller('restaurant/leader')
 export class LeaderController {
@@ -10,6 +10,7 @@ export class LeaderController {
   
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '방장 방 정보', description: 'jwt토큰을 이용해 자신이 만든 방인지 체크 후 해당 방의 정보를 불러옴.' })
   @Get(':id')
   async getLeaderFoodFareRoom(@Param('id') id: string, @Req() req: Request) {
     const result = await this.leaderService.getLeaderFoodFareRoom(id, req.user.id);
@@ -22,6 +23,8 @@ export class LeaderController {
 
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '주문 성공', description: '해당 방 번호를 param으로 받아 jwt토큰 인증 후 상태를 주문 성공으로 변경' })
+  @ApiParam({ name: 'id', type: Number, description: '업데이트할 방 ID', example: 1, })
   @Patch('update-progress/:id')
   async patch3Progress(@Param('id') id: string, @Req() req: Request) {
     await this.leaderService.patch3Progress(id, req.user.id)
@@ -33,6 +36,8 @@ export class LeaderController {
 
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '파티 해산', description: '해당 방 번호를 param으로 받아 jwt토큰 인증 후 방 해산' })
+  @ApiParam({ name: 'id', type: Number, description: '업데이트할 방 ID', example: 1, })
   @Patch('break-up/:id')
   async patch4progress(@Param('id') id: string, @Req() req: Request) {
     await this.leaderService.patch4Progress(id, req.user.id)

--- a/backend/src/restaurant/restaurant.controller.ts
+++ b/backend/src/restaurant/restaurant.controller.ts
@@ -3,6 +3,7 @@ import { RestaurantService } from './restaurant.service';
 import { FoodFareRoomDto } from './dto/create-food-fare-room.dto';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { Request } from 'express';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 
 @Controller('restaurant')
 export class RestaurantController {
@@ -10,23 +11,28 @@ export class RestaurantController {
 
   @UseGuards(JwtAuthGuard)
   @Post('food-fare-room')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'dutchPay 방 생성', description: 'foodFareRoom을 생성한다. jwt토큰을 이용해 creatorUser에 자신의 Id를 넣는다.' })
   async createFoodFareRoom(@Body() dto: FoodFareRoomDto, @Req() req: Request) {
     return await this.restaurantService.createFoodFareRoom(dto, req.user.id);
   }
 
   @Get('current-rooms')
+  @ApiOperation({ summary: '현재 생성되어 있는 방 목록', description: 'jwt토큰 검사 없이 누구나 볼 수 있음.' })
   async getCurrentRooms() {
     const result = await this.restaurantService.getCurrentRooms();
     return { message: '현재 생성된 방 전체', data: result };
   }
 
   @Get('list')
+  @ApiOperation({ summary: '식당 전체 목록', description: 'jwt토큰 검사 없이 누구나 볼 수 있음.' })
   async getRestaurantList() {
     const result = await this.restaurantService.getRestaurantList();
     return { message: '레스토랑 목록 전체', data: result };
   }
 
   @Get('user-list/:id')
+  @ApiOperation({ summary: '선택한 방에 있는 유저 목록', description: 'jwt토큰 검사 없이 누구나 볼 수 있음.' })
   async getUserInRoom(@Param('id') id: string) {
     const result = await this.restaurantService.getUserInRoom(id);
     return { message: `${id}방에 참여한 유저 목록`, data: result };


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

- Swagger 문서에서 **예시(example)**와 인증 가이드가 부족해, 신규/외부 개발자가 테스트 시 401(Authorization 누락) 등 혼선을 겪는 문제를 개선합니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

- POST /restaurant/food-fare-room에 @ApiBearerAuth('access-token') 적용 → Swagger UI의 Authorize 설정이 자동으로 헤더에 반영되어 401 감소
- 엔드포인트 설명(@ApiOperation) 및 예시 보강

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

- 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

- Api설명 방식이 적절한지

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

- 없음

## 📚 관련된 Issue나 Notion, 문서

- 없음

## 🖥 작동하는 모습

- 없음