### PR TITLE
✨ feat(member, controller): add JWT self-authentication and ApiResponse annotations

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Post, Body, HttpCode, Get, UseGuards, Req } from '@nestjs/c
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 @Controller('auth')
 export class AuthController {
@@ -10,6 +10,21 @@ export class AuthController {
 
   @Post('login')
   @HttpCode(200)
+  @ApiOperation({ summary: '로그인', description: 'db에 있는 이메일과 비밀번호인지 체크후 jwt토큰 발급. 토큰 복사 후 사용.' })
+  @ApiOkResponse({
+    description: '로그인 성공',
+    content: {
+      'application/json': {
+        example: {
+          accessToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImVtYWlsIjoiYWxpY2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MjcwMDAwMDAsImV4cCI6MTcyNzAwMDkwMH0.XxYyZz-EXAMPLE_SIGNATURE',
+          tokenType: 'Bearer',
+          expiresIn: '15m',
+        },
+      },
+    },
+  })
+  
   async login(@Body() loginDto: LoginDto ) {
     const user = await this.authService.userAuth(loginDto);
     return this.authService.login(user);
@@ -18,7 +33,20 @@ export class AuthController {
   @Get('me')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'jwt토큰 적용 체크', description: '우측 상단의 Authorize에 jwt토큰 넣은 후 실행' })
+  @ApiOkResponse({
+    description: '성공 시 사용자 정보',
+    content: {
+      'application/json': {
+        example: {
+          id: 1,
+          email: 'alice@example.com',
+          userStuNum: 20231234,
+        },
+      },
+    },
+  })
   getMe(@Req() req) {
-  return req.user; // DB 조회 필요 없으면 이 정도로 충분
+  return req.user;
   }
 }

--- a/backend/src/restaurant/leader/leader.controller.ts
+++ b/backend/src/restaurant/leader/leader.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Param, Patch, Req, UseGuards } from '@nestjs/common';
 import { LeaderService } from './leader.service';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { Request } from 'express';
-import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 
 @Controller('restaurant/leader')
 export class LeaderController {
@@ -11,6 +11,38 @@ export class LeaderController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '방장 방 정보', description: 'jwt토큰을 이용해 자신이 만든 방인지 체크 후 해당 방의 정보를 불러옴.' })
+  @ApiResponse({
+    description: '방장용 상세 정보',
+    content: {
+      'application/json': {
+        example: {
+          message: '1번 방 정보',
+          data: {
+            restaurantName: '',
+            minUser: 3,
+            deadline: '2025-07-07T15:30:00.000Z',
+            deliveryFee: 2000,
+            user: [
+              {
+                userId: 20231234,
+                userName: '',
+                foodOrder: [
+                  { itemName: '', quantity: 1, price: 12000 },
+                ],
+              },
+              {
+                userId: 20235678,
+                userName: '',
+                foodOrder: [
+                  { itemName: '', quantity: 2, price: 10000 },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+  })
   @Get(':id')
   async getLeaderFoodFareRoom(@Param('id') id: string, @Req() req: Request) {
     const result = await this.leaderService.getLeaderFoodFareRoom(id, req.user.id);
@@ -25,6 +57,14 @@ export class LeaderController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '주문 성공', description: '해당 방 번호를 param으로 받아 jwt토큰 인증 후 상태를 주문 성공으로 변경' })
   @ApiParam({ name: 'id', type: Number, description: '업데이트할 방 ID', example: 1, })
+  @ApiOkResponse({
+    description: '업데이트 결과 메시지',
+    content: {
+      'application/json': {
+        example: { message: 'foodFareRoom ID 1번 방에서 progress 3으로 변경' },
+      },
+    },
+  })
   @Patch('update-progress/:id')
   async patch3Progress(@Param('id') id: string, @Req() req: Request) {
     await this.leaderService.patch3Progress(id, req.user.id)
@@ -38,6 +78,14 @@ export class LeaderController {
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '파티 해산', description: '해당 방 번호를 param으로 받아 jwt토큰 인증 후 방 해산' })
   @ApiParam({ name: 'id', type: Number, description: '업데이트할 방 ID', example: 1, })
+  @ApiOkResponse({
+    description: '업데이트 결과 메시지',
+    content: {
+      'application/json': {
+        example: { message: 'foodFareRoom ID 1번 방에서 progress 4로 변경' },
+      },
+    },
+  })
   @Patch('break-up/:id')
   async patch4progress(@Param('id') id: string, @Req() req: Request) {
     await this.leaderService.patch4Progress(id, req.user.id)

--- a/backend/src/restaurant/member/member.controller.ts
+++ b/backend/src/restaurant/member/member.controller.ts
@@ -1,23 +1,63 @@
-import { Controller, Get, Param, Patch } from '@nestjs/common';
+import { Controller, Get, Param, Patch, Req, UseGuards } from '@nestjs/common';
 import { MemberService } from './member.service';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { Request } from 'express';
 
 @Controller('restaurant/member')
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
 
-  
-  @Get('/:roomId/:userId')
-  async getMemberMenu(@Param('userId') userId: string, @Param('roomId') roomId: string) {
-    const result = await this.memberService.getMemberMenu(+userId, +roomId)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @Get('/:roomId')
+  @ApiOperation({ summary: '내가 시킨 메뉴 조회', description: 'jwt토큰 인증 후 자신이 만든 방만 보이게. 현재 참여코드가 없음'})
+  @ApiParam({ name: 'id', type: Number, description: '방 ID', example: 1 })
+  @ApiOkResponse({
+    description: '성공 시 내 주문 항목을 반환',
+    content: {
+      'application/json': {
+        example: {
+          message: '1번방에서 내가 시킨 메뉴',
+          data: {
+            foodJoinUserId: 1,
+            restaurantName: '',
+            deadline: 'Mon Jul 07 2025 15:30:00 GMT+0000 (Coordinated Universal Time)',
+            deliveryFee: 2000,
+            memberCount: 2,
+            myOrderItems: [
+              { itemName: '', quantity: 1, price: 12000 },
+            ],
+          },
+        },
+      },
+    },
+  })
+  async getMemberMenu(@Param('roomId') roomId: string, @Req() req: Request) {
+    const result = await this.memberService.getMemberMenu(+roomId, req.user.id)
     return {
       message: `${roomId}방에서 내가 시킨 메뉴`,
       data: result
     };
   }
 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '배달 수령 확인', description: 'jwt토큰 확인 후 자신의 주문에만 상태를 변경가능' })
+  @ApiParam({ name: '배달 수령 확인', type: Number, description: '방 ID', example: 1, })
+  @ApiOkResponse({
+    description: '성공 메시지',
+    content: {
+      'application/json': {
+        example: {
+          message: 'foodJoinUser 1번 방에서 delivery_confirmation 1로 변경',
+        },
+      },
+    },
+  })
   @Patch('delivery-confirmation/:id')
-  async patch2Delivery(@Param('id') id: string) {
-    await this.memberService.patch2Delivery(id)
+  async patch2Delivery(@Param('id') id: string, @Req() req: Request) {
+    await this.memberService.patch2Delivery(id, req.user.id)
     return {
       message: `foodJoinUser ${id}번 방에서 delivery_confirmation 1로 변경`,
     };

--- a/backend/src/restaurant/restaurant.controller.ts
+++ b/backend/src/restaurant/restaurant.controller.ts
@@ -3,7 +3,7 @@ import { RestaurantService } from './restaurant.service';
 import { FoodFareRoomDto } from './dto/create-food-fare-room.dto';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { Request } from 'express';
-import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCreatedResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 @Controller('restaurant')
 export class RestaurantController {
@@ -13,12 +13,56 @@ export class RestaurantController {
   @Post('food-fare-room')
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'dutchPay 방 생성', description: 'foodFareRoom을 생성한다. jwt토큰을 이용해 creatorUser에 자신의 Id를 넣는다.' })
+  @ApiCreatedResponse({
+    description: '생성된 방 정보',
+    content: {
+      'application/json': {
+        example: {
+          id: 5,
+          creatorUser: { id: 1 },
+          restaurant: { id: 1 },
+          deadline: '2024-09-20T20:00:00.000Z',
+          minMember: 4,
+        },
+      },
+    },
+  })
   async createFoodFareRoom(@Body() dto: FoodFareRoomDto, @Req() req: Request) {
     return await this.restaurantService.createFoodFareRoom(dto, req.user.id);
   }
 
   @Get('current-rooms')
   @ApiOperation({ summary: '현재 생성되어 있는 방 목록', description: 'jwt토큰 검사 없이 누구나 볼 수 있음.' })
+  @ApiOkResponse({
+    description: '현재 진행중(progress=0)인 방 리스트',
+    content: {
+      'application/json': {
+        example: {
+          message: '현재 생성된 방 전체',
+          data: [
+            {
+              id: 2,
+              restaurantName: '',
+              deliveryFee: 3000,
+              minUser: 2,
+              currentUsers: 2,
+              deadline: '2025-07-08T18:00:00.000Z',
+              imageUrl: null,
+            },
+            {
+              id: 3,
+              restaurantName: '',
+              deliveryFee: 2000,
+              minUser: 4,
+              currentUsers: 1,
+              deadline: '2024-09-20T20:00:00.000Z',
+              imageUrl: null,
+            },
+          ],
+        },
+      },
+    },
+  })
   async getCurrentRooms() {
     const result = await this.restaurantService.getCurrentRooms();
     return { message: '현재 생성된 방 전체', data: result };
@@ -26,6 +70,21 @@ export class RestaurantController {
 
   @Get('list')
   @ApiOperation({ summary: '식당 전체 목록', description: 'jwt토큰 검사 없이 누구나 볼 수 있음.' })
+  @ApiOkResponse({
+    description: '레스토랑 전체 리스트',
+    content: {
+      'application/json': {
+        example: {
+          message: '레스토랑 목록 전체',
+          data: [
+            { id: 1, restaurantName: '', deliveryFee: 2000, imageUrl: null, businessHours: '' },
+            { id: 2, restaurantName: '', deliveryFee: 3000, imageUrl: null, businessHours: '' },
+            { id: 3, restaurantName: '', deliveryFee: 4000, imageUrl: null, businessHours: '' },
+          ],
+        },
+      },
+    },
+  })
   async getRestaurantList() {
     const result = await this.restaurantService.getRestaurantList();
     return { message: '레스토랑 목록 전체', data: result };
@@ -33,6 +92,20 @@ export class RestaurantController {
 
   @Get('user-list/:id')
   @ApiOperation({ summary: '선택한 방에 있는 유저 목록', description: 'jwt토큰 검사 없이 누구나 볼 수 있음.' })
+  @ApiOkResponse({
+    description: '해당 방의 참여 유저 리스트',
+    content: {
+      'application/json': {
+        example: {
+          message: '1방에 참여한 유저 목록',
+          data: [
+            { user_id: 20231234, name: '', student_number: 20231234, is_creator: true },
+            { user_id: 20235678, name: '', student_number: 20235678, is_creator: false },
+          ],
+        },
+      },
+    },
+  })
   async getUserInRoom(@Param('id') id: string) {
     const result = await this.restaurantService.getUserInRoom(id);
     return { message: `${id}방에 참여한 유저 목록`, data: result };

--- a/backend/src/user/dto/create-user.dto.ts
+++ b/backend/src/user/dto/create-user.dto.ts
@@ -1,15 +1,20 @@
-import { IsEmail, IsInt, IsString, Length, MinLength } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEmail, IsInt, IsString, MinLength } from "class-validator";
 
 export class CreateUserDto {
+  @ApiProperty({ type: String, description: '이메일 형식', required: true, example: 'aswq@example.com' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ type: String, description: '이름', required: true, example: 'aswq' })
   @IsString()
   name: string;
 
+  @ApiProperty({ type: Number, description: '숫자 형식', required: true, example: '2225446' })
   @IsInt()
   studentNumber: number;
 
+  @ApiProperty({ type: String, description: '비밀번호 최소 8자', required: true, example: 'alice@example.com' })
   @IsString()
   @MinLength(8)
   password: string;

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,12 +1,28 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
+import { ApiCreatedResponse } from '@nestjs/swagger';
 
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Post('signup')
+  @ApiCreatedResponse({
+    description: '유저 회원가입 성공',
+    schema: {
+      example: {
+        message: '유저 회원가입 성공',
+        data: {
+          id: 4,
+          email: 'aswq@example.com',
+          name: 'aswq',
+          studentNumber: 2225446,
+          totalDiscount: 0,
+        },
+      },
+    },
+  })
   async signUpUser(@Body() createUserDto: CreateUserDto) {
     const result = await this.userService.signUpUser(createUserDto);
     return { message: '유저 회원가입 성공', date: result }


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

- 모든 컨트롤러의 API 응답 형식을 일관되게 관리하기 위해 @ApiResponse를 추가
- Member 모듈에 JWT 기반 자기 자신 인증 로직을 도입하여 보안 강화

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

- 모든 컨트롤러 엔드포인트에 @ApiResponse를 적용하여 Swagger 문서에서 응답 스펙 확인 가능
- MemberController 및 MemberService에 JWT 인증 기반 자기 자신 검증 로직 추가
- JWT 토큰을 활용하여 요청자가 본인임을 확인 후 서비스 로직 처리

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

- 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

- 없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

- 없음

## 📚 관련된 Issue나 Notion, 문서

- 없음

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
