### PR TITLE
✨feat(restaurant): align SQL schema/entities; add room progress update, menu selection, and member orders/delivery confirmation APIs

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -25,7 +25,7 @@ import { AuthModule } from './auth/auth.module';
         password: config.get<string>('DB_PASSWORD'),
         database: config.get<string>('DB_DATABASE'),
         entities: [__dirname + '/**/*.entity{.ts,.js}'],
-        synchronize: true,
+        synchronize: false,
         namingStrategy: new SnakeNamingStrategy(),
     }),
   }),

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsString } from "class-validator";
+import { IsEmail, IsString, MinLength } from "class-validator";
 
 export class LoginDto {
     @ApiProperty({ type: String, description: '이메일 형식', required: true, example: 'alice@example.com' })

--- a/backend/src/restaurant/Type/user-list-response.type.ts
+++ b/backend/src/restaurant/Type/user-list-response.type.ts
@@ -1,6 +1,6 @@
 export class UserResponseType {
-  user_id: number;
+  user_id: string;
   name: string;
-  student_number: number;
+  student_number: string;
   is_creator: boolean;
 }

--- a/backend/src/restaurant/dto/create-food-fare-room.dto.ts
+++ b/backend/src/restaurant/dto/create-food-fare-room.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsISO8601 } from 'class-validator';
+import { IsInt, IsISO8601, Min } from 'class-validator';
 
 export class FoodFareRoomDto {
   @ApiProperty({ type: Number, description: '식당 번호', required: true, example: 1 })
@@ -7,6 +7,7 @@ export class FoodFareRoomDto {
   restaurantId: number;
 
   @ApiProperty({ type: Number, description: '주문을 시작하기 위해 필요한 최소 인원', required: true, example: 4 })
+  @Min(1)
   @IsInt()
   minMember: number;
 

--- a/backend/src/restaurant/dto/create-food-order.dto.ts
+++ b/backend/src/restaurant/dto/create-food-order.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { ArrayMinSize, IsArray, IsDefined, IsInt, Min, ValidateNested } from "class-validator";
+
+export class CreateFoodOrderDto {
+  @ApiProperty({ type: Number, description: '메뉴 번호', required: true, example: 1 })
+  @IsInt()
+  @IsDefined()
+  @Min(1)
+  foodItemId: number;
+  
+  @ApiProperty({ type: Number, description: '수량', required: true, example: 1 })
+  @IsInt()
+  @Min(1)
+  quantity: number;
+}
+
+export class CreateMyOrdersDto {
+  @ApiProperty({
+    type: [CreateFoodOrderDto],
+    description: '주문 항목 목록',
+    required: true,
+    example: [
+      { foodItemId: 1, quantity: 2 },
+      { foodItemId: 3, quantity: 1 },
+    ],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateFoodOrderDto)
+  items: CreateFoodOrderDto[];
+}

--- a/backend/src/restaurant/entities/food-fare-room.entity.ts
+++ b/backend/src/restaurant/entities/food-fare-room.entity.ts
@@ -4,6 +4,7 @@ import {
   Column,
   OneToMany,
   ManyToOne,
+  Unique,
 } from 'typeorm';
 import { FoodResult } from './food-result.entity';
 import { Restaurant } from './restaurant.entity';
@@ -11,6 +12,7 @@ import { FoodJoinUser } from './food-join-user.entity';
 import { User } from 'src/user/entities/user.entity';
 
 @Entity()
+@Unique(['creatorUser', 'restaurant', 'deadline'])
 export class FoodFareRoom {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/src/restaurant/entities/food-item.entity.ts
+++ b/backend/src/restaurant/entities/food-item.entity.ts
@@ -4,11 +4,13 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
   OneToMany,
+  Unique,
 } from 'typeorm';
 import { Restaurant } from './restaurant.entity';
 import { FoodOrder } from './food-order.entity';
 
 @Entity()
+@Unique(['restaurant', 'itemName'])
 export class FoodItem {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/src/restaurant/entities/food-join-user.entity.ts
+++ b/backend/src/restaurant/entities/food-join-user.entity.ts
@@ -4,12 +4,14 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
   ManyToOne,
+  Unique,
 } from 'typeorm';
 import { FoodOrder } from './food-order.entity';
 import { FoodFareRoom } from './food-fare-room.entity';
 import { User } from 'src/user/entities/user.entity';
 
 @Entity()
+@Unique(['user', 'foodFareRoom'])
 export class FoodJoinUser {
   @PrimaryGeneratedColumn()
   id: number;
@@ -17,8 +19,8 @@ export class FoodJoinUser {
   @ManyToOne(() => User, (user) => user.foodJoinUsers, { onDelete: 'CASCADE' })
   user: User;
 
-  @Column()
-  deliveryConfirmation: number;
+  @Column({ default: '0' })
+  deliveryConfirmation: string;
 
   @ManyToOne(() => FoodFareRoom, (foodFareRoom) => foodFareRoom.foodJoinUsers, {
     onDelete: 'CASCADE',

--- a/backend/src/restaurant/entities/food-join-user.entity.ts
+++ b/backend/src/restaurant/entities/food-join-user.entity.ts
@@ -4,14 +4,12 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
   ManyToOne,
-  Unique,
 } from 'typeorm';
 import { FoodOrder } from './food-order.entity';
 import { FoodFareRoom } from './food-fare-room.entity';
 import { User } from 'src/user/entities/user.entity';
 
 @Entity()
-@Unique(['user', 'foodFareRoom'])
 export class FoodJoinUser {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/src/restaurant/entities/food-order.entity.ts
+++ b/backend/src/restaurant/entities/food-order.entity.ts
@@ -1,7 +1,9 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { FoodItem } from './food-item.entity';
 import { FoodJoinUser } from './food-join-user.entity';
+
 @Entity()
+@Unique(['foodJoinUser', 'foodItem'])
 export class FoodOrder {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/src/restaurant/entities/food-result.entity.ts
+++ b/backend/src/restaurant/entities/food-result.entity.ts
@@ -11,7 +11,7 @@ export class FoodResult {
   })
   foodFareRoom: FoodFareRoom;
 
-  @Column()
+  @Column({ default: 0 })
   progress: number;
 
   @Column()

--- a/backend/src/restaurant/entities/restaurant.entity.ts
+++ b/backend/src/restaurant/entities/restaurant.entity.ts
@@ -1,8 +1,9 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, Unique } from 'typeorm';
 import { FoodItem } from './food-item.entity';
 import { FoodFareRoom } from './food-fare-room.entity';
 
 @Entity()
+@Unique(['restaurantName', 'phoneNumber'])
 export class Restaurant {
   @PrimaryGeneratedColumn()
   id: number;

--- a/backend/src/restaurant/leader/Type/food-room-leader-response.type.ts
+++ b/backend/src/restaurant/leader/Type/food-room-leader-response.type.ts
@@ -7,7 +7,7 @@ class FoodOrderInformationType {
 }
 
 class JoinUserInformationType {
-  userId: number;
+  userId: string;
   userName: string;
   @Type(() => FoodOrderInformationType)
   foodOrder: FoodOrderInformationType[];

--- a/backend/src/restaurant/leader/leader.controller.ts
+++ b/backend/src/restaurant/leader/leader.controller.ts
@@ -52,7 +52,7 @@ export class LeaderController {
       data: result,
     };
   }
-
+  
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '주문 성공', description: '해당 방 번호를 param으로 받아 jwt토큰 인증 후 상태를 주문 성공으로 변경' })
@@ -61,16 +61,37 @@ export class LeaderController {
     description: '업데이트 결과 메시지',
     content: {
       'application/json': {
-        example: { message: 'foodFareRoom ID 1번 방에서 progress 3으로 변경' },
+        example: { message: 'foodFareRoom ID 1번 방에서 progress 1으로 변경' },
       },
     },
   })
-  @Patch('update-progress/:id')
-  async patch3Progress(@Param('id') id: string, @Req() req: Request) {
-    await this.leaderService.patch3Progress(id, req.user.id)
+  @Patch('update-progress1/:id')
+  async patch1Progress(@Param('id') id: string, @Req() req: Request) {
+    await this.leaderService.patch1Progress(id, req.user.id)
 
     return {
-      message: `foodFareRoom ID ${id}번 방에서 progress 3으로 변경`,
+      message: `foodFareRoom ID ${id}번 방에서 progress 1으로 변경`,
+    };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '주문 중', description: '해당 방 번호를 param으로 받아 jwt토큰 인증 후 상태를 주문 성공으로 변경' })
+  @ApiParam({ name: 'id', type: Number, description: '업데이트할 방 ID', example: 1, })
+  @ApiOkResponse({
+    description: '업데이트 결과 메시지',
+    content: {
+      'application/json': {
+        example: { message: 'foodFareRoom ID 1번 방에서 progress 2으로 변경' },
+      },
+    },
+  })
+  @Patch('update-progress2/:id')
+  async patch2Progress(@Param('id') id: string, @Req() req: Request) {
+    await this.leaderService.patch2Progress(id, req.user.id)
+
+    return {
+      message: `foodFareRoom ID ${id}번 방에서 progress 2으로 변경`,
     };
   }
 
@@ -82,16 +103,16 @@ export class LeaderController {
     description: '업데이트 결과 메시지',
     content: {
       'application/json': {
-        example: { message: 'foodFareRoom ID 1번 방에서 progress 4로 변경' },
+        example: { message: 'foodFareRoom ID 1번 방에서 progress 3로 변경' },
       },
     },
   })
-  @Patch('break-up/:id')
-  async patch4progress(@Param('id') id: string, @Req() req: Request) {
-    await this.leaderService.patch4Progress(id, req.user.id)
+  @Patch('update-progress3/:id')
+  async patch3progress(@Param('id') id: string, @Req() req: Request) {
+    await this.leaderService.patch3Progress(id, req.user.id)
 
     return {
-      message: `foodFareRoom ID ${id}방에서 progress 4로 변경`,
+      message: `foodFareRoom ID ${id}방에서 progress 3로 변경`,
     };
   }
 }

--- a/backend/src/restaurant/leader/leader.service.ts
+++ b/backend/src/restaurant/leader/leader.service.ts
@@ -46,6 +46,44 @@ export class LeaderService {
     };
   }
 
+  async patch1Progress(id: string, userId: number): Promise<void> {
+    const roomProgress = await this.foodResultRepo.findOne({
+      where: {foodFareRoom: {id: +id}},
+      relations: ['foodFareRoom', 'foodFareRoom.creatorUser'],
+    })
+
+    if(!roomProgress) {
+      throw new NotFoundException(`foodResult에 ${id}번 방이 존재하지 않음`)
+    }
+
+    if (roomProgress.foodFareRoom.creatorUser.id !== userId) {
+      throw new ForbiddenException('본인이 생성한 방만 상태를 변경할 수 있습니다.');
+    }
+
+    roomProgress.progress = 1;
+
+    await this.foodResultRepo.save(roomProgress)
+  }
+
+  async patch2Progress(id: string, userId: number): Promise<void> {
+    const roomProgress = await this.foodResultRepo.findOne({
+      where: {foodFareRoom: {id: +id}},
+      relations: ['foodFareRoom', 'foodFareRoom.creatorUser'],
+    })
+
+    if(!roomProgress) {
+      throw new NotFoundException(`foodResult에 ${id}번 방이 존재하지 않음`)
+    }
+
+    if (roomProgress.foodFareRoom.creatorUser.id !== userId) {
+      throw new ForbiddenException('본인이 생성한 방만 상태를 변경할 수 있습니다.');
+    }
+
+    roomProgress.progress = 2;
+
+    await this.foodResultRepo.save(roomProgress)
+  }
+
   async patch3Progress(id: string, userId: number): Promise<void> {
     const roomProgress = await this.foodResultRepo.findOne({
       where: {foodFareRoom: {id: +id}},
@@ -61,25 +99,6 @@ export class LeaderService {
     }
 
     roomProgress.progress = 3;
-
-    await this.foodResultRepo.save(roomProgress)
-  }
-
-  async patch4Progress(id: string, userId: number): Promise<void> {
-    const roomProgress = await this.foodResultRepo.findOne({
-      where: {foodFareRoom: {id: +id}},
-      relations: ['foodFareRoom', 'foodFareRoom.creatorUser'],
-    })
-
-    if(!roomProgress) {
-      throw new NotFoundException(`foodResult에 ${id}번 방이 존재하지 않음`)
-    }
-
-    if (roomProgress.foodFareRoom.creatorUser.id !== userId) {
-      throw new ForbiddenException('본인이 생성한 방만 상태를 변경할 수 있습니다.');
-    }
-
-    roomProgress.progress = 4;
 
     await this.foodResultRepo.save(roomProgress)
   }

--- a/backend/src/restaurant/member/member.controller.ts
+++ b/backend/src/restaurant/member/member.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Patch, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { MemberService } from './member.service';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
@@ -10,9 +10,20 @@ export class MemberController {
 
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
-  @Get('/:roomId')
-  @ApiOperation({ summary: '내가 시킨 메뉴 조회', description: 'jwt토큰 인증 후 자신이 만든 방만 보이게. 현재 참여코드가 없음'})
-  @ApiParam({ name: 'id', type: Number, description: '방 ID', example: 1 })
+  @Post(':roomId')
+  async joinFoodRoom(@Param('roomId') roomId: string, @Req() req: Request) {
+    const result = await this.memberService.joinFoodRoom(+roomId, req.user.id);
+    return {
+      message: `member가 ${roomId}방 참여`,
+      data: result
+    }
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @Get(':roomId')
+  @ApiOperation({ summary: '내가 시킨 메뉴 조회', description: 'jwt토큰 인증 후 자신이 참여한 방만 보이게. 현재 참여코드가 없음'})
+  @ApiParam({ name: 'roomId', type: Number, description: '내 주문 항목', example: 1 })
   @ApiOkResponse({
     description: '성공 시 내 주문 항목을 반환',
     content: {
@@ -44,7 +55,7 @@ export class MemberController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '배달 수령 확인', description: 'jwt토큰 확인 후 자신의 주문에만 상태를 변경가능' })
-  @ApiParam({ name: '배달 수령 확인', type: Number, description: '방 ID', example: 1, })
+  @ApiParam({ name: 'id', type: Number, description: '방 ID', example: 1, })
   @ApiOkResponse({
     description: '성공 메시지',
     content: {

--- a/backend/src/restaurant/member/member.controller.ts
+++ b/backend/src/restaurant/member/member.controller.ts
@@ -1,16 +1,34 @@
 import { Controller, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { MemberService } from './member.service';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
-import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
 import { Request } from 'express';
 
 @Controller('restaurant/member')
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
-
+  
+  @Post(':roomId')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
-  @Post(':roomId')
+  @ApiOperation({ summary: '해당 방에 참여', description: 'jwt토큰으로 이미 참여한 방인지 체크'})
+  @ApiParam({ name: 'roomId', type: Number, description: '방 번호', example: 2 })
+  @ApiCreatedResponse({
+    description: 'member가 2방에 참여',
+    content: {
+      'application/json': {
+        example: {
+          message: 'member가 2방 참여',
+          data: {
+            id: 5,
+            user: { id: 1 },
+            deliveryConfirmation: 0,
+            foodFareRoom: { id: 2 },
+          },
+        },
+      },
+    },
+  })
   async joinFoodRoom(@Param('roomId') roomId: string, @Req() req: Request) {
     const result = await this.memberService.joinFoodRoom(+roomId, req.user.id);
     return {
@@ -19,11 +37,11 @@ export class MemberController {
     }
   }
 
+  @Get(':roomId')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
-  @Get(':roomId')
   @ApiOperation({ summary: '내가 시킨 메뉴 조회', description: 'jwt토큰 인증 후 자신이 참여한 방만 보이게. 현재 참여코드가 없음'})
-  @ApiParam({ name: 'roomId', type: Number, description: '내 주문 항목', example: 1 })
+  @ApiParam({ name: 'roomId', type: Number, description: '방 번호', example: 1 })
   @ApiOkResponse({
     description: '성공 시 내 주문 항목을 반환',
     content: {
@@ -52,6 +70,7 @@ export class MemberController {
     };
   }
 
+  @Patch('delivery-confirmation/:id')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '배달 수령 확인', description: 'jwt토큰 확인 후 자신의 주문에만 상태를 변경가능' })
@@ -66,7 +85,6 @@ export class MemberController {
       },
     },
   })
-  @Patch('delivery-confirmation/:id')
   async patch2Delivery(@Param('id') id: string, @Req() req: Request) {
     await this.memberService.patch2Delivery(id, req.user.id)
     return {

--- a/backend/src/restaurant/member/member.service.ts
+++ b/backend/src/restaurant/member/member.service.ts
@@ -1,63 +1,84 @@
-import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FoodJoinUser } from '../entities/food-join-user.entity';
 import { Repository } from 'typeorm';
 import { FoodRoomMemberResponseType } from './Type/food-room-member-response.type';
+import { FoodFareRoom } from '../entities/food-fare-room.entity';
 
 @Injectable()
 export class MemberService {
   constructor(
     @InjectRepository(FoodJoinUser)
     private readonly foodJoinUserRepo: Repository<FoodJoinUser>,
+    @InjectRepository(FoodFareRoom)
+    private readonly foodFareRoomRepo: Repository<FoodFareRoom>,
   ) {}
 
+  async joinFoodRoom(roomId: number, userId: number): Promise<FoodJoinUser> {
+    const room = await this.foodFareRoomRepo.findOne({
+      where: { id: roomId },
+    });
+
+    if (!room) throw new NotFoundException(`roomId=${roomId} 방이 존재하지 않습니다.`);
+
+    const existing = await this.foodJoinUserRepo.findOne({
+      where: { foodFareRoom: { id: roomId }, user: { id: userId } },
+    });
+
+    if (existing) {
+      throw new ConflictException('이미 해당 방에 참여했습니다.');
+    }
+
+    const savedJoinUser = this.foodJoinUserRepo.create({
+      user: { id: userId },
+      foodFareRoom: { id: roomId },
+    });
+    return await this.foodJoinUserRepo.save(savedJoinUser);
+  }
+
   async getMemberMenu(roomId: number, userId: number): Promise<FoodRoomMemberResponseType> {
-        const foodRoomMember = await this.foodJoinUserRepo.findOne({
-            where: {
-                foodFareRoom: { id: roomId },
-                user: { id: userId }
-            },
-            relations: ['user', 'foodFareRoom', 'foodFareRoom.creatorUser', 'foodFareRoom.restaurant', 'foodFareRoom.foodJoinUsers', 'foodOrders', 'foodOrders.foodItem']
-        })
-        
-        if (!foodRoomMember) {
-          throw new NotFoundException(`Member not found for userId=${userId}, roomId=${roomId}`);
-        }
+    const foodRoomMember = await this.foodJoinUserRepo.findOne({
+        where: {
+            foodFareRoom: { id: roomId },
+            user: { id: userId }
+        },
+        relations: ['user', 'foodFareRoom', 'foodFareRoom.creatorUser', 'foodFareRoom.restaurant', 'foodFareRoom.foodJoinUsers', 'foodOrders', 'foodOrders.foodItem']
+    })
+    
+    if (!foodRoomMember) {
+      throw new NotFoundException(`해당 방에 참여한 기록이 없습니다. userId=${userId}, roomId=${roomId}`);
+    }
 
-        if(foodRoomMember.foodFareRoom.creatorUser.id !== userId) {
-          throw new ForbiddenException('본인이 참여한 방만 조회할 수 있습니다.')
-        }
-
-        return {
-              foodJoinUserId: foodRoomMember.user.id,
-              restaurantName: foodRoomMember.foodFareRoom.restaurant.restaurantName,
-              deadline: foodRoomMember.foodFareRoom.deadline.toString(),
-              deliveryFee: foodRoomMember.foodFareRoom.restaurant.deliveryFee,
-              memberCount: foodRoomMember.foodFareRoom.foodJoinUsers.length,
-              myOrderItems: foodRoomMember.foodOrders.map((order) => ({
-                itemName: order.foodItem.itemName,
-                quantity: order.quantity,
-                price: order.foodItem.price
-              }))
-        }
+    return {
+          foodJoinUserId: foodRoomMember.user.id,
+          restaurantName: foodRoomMember.foodFareRoom.restaurant.restaurantName,
+          deadline: foodRoomMember.foodFareRoom.deadline.toString(),
+          deliveryFee: foodRoomMember.foodFareRoom.restaurant.deliveryFee,
+          memberCount: foodRoomMember.foodFareRoom.foodJoinUsers.length,
+          myOrderItems: foodRoomMember.foodOrders.map((order) => ({
+            itemName: order.foodItem.itemName,
+            quantity: order.quantity,
+            price: order.foodItem.price
+          }))
+    }
     }
 
     async patch2Delivery(id: string, userId: number): Promise<void> {
-        const foodJoinUser = await this.foodJoinUserRepo.findOne({
-            where: {id: +id},
-            relations: ['foodFareRoom.creatorUser'],
-        })
+      const foodJoinUser = await this.foodJoinUserRepo.findOne({
+          where: {id: +id},
+          relations: ['foodFareRoom.creatorUser'],
+      })
 
-        if(!foodJoinUser) {
-            throw new NotFoundException(`foodJoinUser에 ${id}번 방이 존재하지 않음`)
-        }
+      if(!foodJoinUser) {
+          throw new NotFoundException(`foodJoinUser에 ${id}번 방이 존재하지 않음`)
+      }
 
-        if(foodJoinUser.foodFareRoom.creatorUser.id !== userId) {
-          throw new ForbiddenException('본인이 참여한 방만 상태를 변경할 수 있습니다.')
-        }
+      if(foodJoinUser.foodFareRoom.creatorUser.id !== userId) {
+        throw new ForbiddenException('본인이 참여한 방만 상태를 변경할 수 있습니다.')
+      }
 
-        foodJoinUser.deliveryConfirmation = 1;
+      foodJoinUser.deliveryConfirmation = '1';
 
-        await this.foodJoinUserRepo.save(foodJoinUser)
+      await this.foodJoinUserRepo.save(foodJoinUser)
     }
 }

--- a/backend/src/restaurant/restaurant.module.ts
+++ b/backend/src/restaurant/restaurant.module.ts
@@ -10,9 +10,11 @@ import { LeaderController } from './leader/leader.controller';
 import { LeaderService } from './leader/leader.service';
 import { MemberController } from './member/member.controller';
 import { MemberService } from './member/member.service';
+import { FoodOrder } from './entities/food-order.entity';
+import { FoodItem } from './entities/food-item.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Restaurant, FoodFareRoom, FoodResult, FoodJoinUser,])],
+  imports: [TypeOrmModule.forFeature([Restaurant, FoodFareRoom, FoodResult, FoodJoinUser, FoodOrder, FoodItem])],
   controllers: [RestaurantController, LeaderController, MemberController],
   providers: [RestaurantService, LeaderService, MemberService],
 })

--- a/backend/src/restaurant/restaurant.service.ts
+++ b/backend/src/restaurant/restaurant.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FoodFareRoom } from './entities/food-fare-room.entity';
@@ -9,6 +9,9 @@ import { FoodFareRoomDto } from './dto/create-food-fare-room.dto';
 import { CurrentFoodRoomsResponseType } from './Type/current-food-rooms-response.type';
 import { ListResponseType } from './Type/list-response.type';
 import { UserResponseType } from './Type/user-list-response.type';
+import { CreateFoodOrderDto } from './dto/create-food-order.dto';
+import { FoodOrder } from './entities/food-order.entity';
+import { FoodItem } from './entities/food-item.entity';
 
 @Injectable()
 export class RestaurantService {
@@ -17,6 +20,8 @@ export class RestaurantService {
     @InjectRepository(FoodResult) private readonly foodResultRepo: Repository<FoodResult>,
     @InjectRepository(FoodJoinUser) private readonly foodJoinUserRepo: Repository<FoodJoinUser>,
     @InjectRepository(Restaurant) private readonly restaurantRepo: Repository<Restaurant>,
+    @InjectRepository(FoodOrder) private readonly foodOrderRepo: Repository<FoodOrder>,
+    @InjectRepository(FoodItem) private readonly foodItemRepo: Repository<FoodItem>,
   ) {}
 
   async createFoodFareRoom(dto: FoodFareRoomDto, userId: number): Promise<FoodFareRoom> {
@@ -43,6 +48,69 @@ export class RestaurantService {
     await this.foodJoinUserRepo.save(foodJoinUser);
 
     return savedRoom;
+  }
+
+  async createFoodOrder(roomId: number, dto: CreateFoodOrderDto, userId: number) {
+    const room = await this.foodFareRoomRepo.findOne({
+      where: { id: roomId },
+      relations: ['restaurant'],
+    });
+    if (!room) throw new NotFoundException('방을 찾을 수 없습니다.');
+
+    const result = await this.foodResultRepo.findOne({
+      where: { foodFareRoom: { id: room.id }, progress: 0 },
+    });
+    if (!result) throw new ForbiddenException('이미 진행이 종료된 방입니다.');
+    if (room.deadline <= new Date()) {
+      throw new ForbiddenException('마감 시간이 지나 주문할 수 없습니다.');
+    }
+
+    const join = await this.foodJoinUserRepo.findOne({
+      where: { foodFareRoom: { id: room.id }, user: { id: userId } },
+      relations: ['foodFareRoom', 'user'],
+    });
+    if (!join) throw new ForbiddenException('해당 방에 참여하지 않았습니다.');
+
+    const foodItem = await this.foodItemRepo.findOne({
+      where: { id: dto.foodItemId },
+      relations: ['restaurant'],
+    });
+    if (!foodItem) throw new NotFoundException('메뉴(FoodItem)를 찾을 수 없습니다.');
+    if (foodItem.restaurant.id !== room.restaurant.id) {
+      throw new ForbiddenException('방의 레스토랑과 다른 메뉴는 주문할 수 없습니다.');
+    }
+
+    const created = this.foodOrderRepo.create({
+      foodJoinUser: { id: join.id },
+      foodItem: { id: foodItem.id },
+      quantity: dto.quantity,
+    });
+    await this.foodOrderRepo.save(created);
+
+    const myOrders = await this.foodOrderRepo.find({
+      where: { foodJoinUser: { id: join.id } },
+      relations: ['foodItem'],
+      order: { id: 'ASC' },
+    });
+
+    const items = myOrders.map(o => ({
+      orderItemId: o.id,
+      foodItemId: o.foodItem.id,
+      itemName: o.foodItem.itemName,
+      unitPrice: o.foodItem.price,
+      quantity: o.quantity,
+      subtotal: o.foodItem.price * o.quantity,
+    }));
+    const myTotal = items.reduce((s, it) => s + it.subtotal, 0);
+
+    return {
+      message: '주문이 저장되었습니다.',
+      data: {
+        foodJoinUserId: join.id,
+        myOrderItems: items,
+        myTotal,
+      },
+    };
   }
 
   async getCurrentRooms(): Promise<CurrentFoodRoomsResponseType[]> {

--- a/backend/src/restaurant/restaurant.service.ts
+++ b/backend/src/restaurant/restaurant.service.ts
@@ -38,7 +38,6 @@ export class RestaurantService {
     const foodJoinUser = this.foodJoinUserRepo.create({
       user: { id: userId },
       foodFareRoom: savedRoom,
-      deliveryConfirmation: 0,
       foodOrders: [],
     });
     await this.foodJoinUserRepo.save(foodJoinUser);

--- a/backend/src/user/dto/create-user.dto.ts
+++ b/backend/src/user/dto/create-user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsInt, IsString, MinLength } from "class-validator";
+import { IsEmail, IsInt, IsNotEmpty, IsString, Length, Matches, MinLength } from "class-validator";
 
 export class CreateUserDto {
   @ApiProperty({ type: String, description: '이메일 형식', required: true, example: 'aswq@example.com' })
@@ -7,12 +7,14 @@ export class CreateUserDto {
   email: string;
 
   @ApiProperty({ type: String, description: '이름', required: true, example: 'aswq' })
+  @IsNotEmpty({ message: '이름은 비어 있을 수 없습니다.' })
   @IsString()
   name: string;
 
-  @ApiProperty({ type: Number, description: '숫자 형식', required: true, example: '2225446' })
-  @IsInt()
-  studentNumber: number;
+  @ApiProperty({ type: String, description: '학번 7글자 숫자 형식', required: true, example: '2225446' })
+  @IsString()
+  @Matches(/^\d{7}$/)
+  studentNumber: string;
 
   @ApiProperty({ type: String, description: '비밀번호 최소 8자', required: true, example: 'alice@example.com' })
   @IsString()

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -7,14 +7,14 @@ export class User {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({ unique: true })
     email: string;
 
     @Column()
     name: string;
 
-    @Column({ type: 'int', unsigned: true })
-    studentNumber: number;
+    @Column({ type: 'varchar', length: 7, unique: true })
+    studentNumber: string;
 
     @Column({ select: false })
     password: string;

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,13 +1,14 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
-import { ApiCreatedResponse } from '@nestjs/swagger';
+import { ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
 
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Post('signup')
+  @ApiOperation({ summary: '회원가입' })
   @ApiCreatedResponse({
     description: '유저 회원가입 성공',
     schema: {

--- a/mysql-init/00_schema.sql
+++ b/mysql-init/00_schema.sql
@@ -126,7 +126,6 @@ CREATE TABLE IF NOT EXISTS food_order (
   created_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   INDEX idx_order_item_id (food_item_id),
   INDEX idx_order_join_user_id (food_join_user_id),
-  UNIQUE KEY uq_order_joinuser_item (food_join_user_id, food_item_id),
   CONSTRAINT fk_order__item
     FOREIGN KEY (food_item_id) REFERENCES food_item(id)
     ON DELETE CASCADE ON UPDATE CASCADE,

--- a/mysql-init/00_schema.sql
+++ b/mysql-init/00_schema.sql
@@ -1,37 +1,45 @@
--- 문자셋/콜레이션 선호가 없으셔서 utf8mb4로 설정했습니다.
+-- 문자셋/콜레이션
 CREATE DATABASE IF NOT EXISTS `db` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 USE `db`;
 
 -- ─────────────────────────────────────────────────────────────
--- users
+-- user  (User 엔티티)
+--  - email: unique
+--  - name: NOT NULL
+--  - student_number: VARCHAR(7) + UNIQUE
+--  - total_discount: NOT NULL DEFAULT 0
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS `user` (
   id               INT AUTO_INCREMENT PRIMARY KEY,
-  email            VARCHAR(255) NOT NULL UNIQUE,
-  name             VARCHAR(100) NOT NULL,
-  student_number   INT DEFAULT 0,
+  email            VARCHAR(100) NOT NULL UNIQUE,
+  name             VARCHAR(50)  NOT NULL,
+  student_number   VARCHAR(7)   NOT NULL,
   password         VARCHAR(255) NOT NULL,
-  total_discount   INT DEFAULT 0,
-  created_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  total_discount   INT          NOT NULL DEFAULT 0,
+  created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_user_student_number (student_number)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ─────────────────────────────────────────────────────────────
--- restaurant
+-- restaurant (Restaurant 엔티티)
+--  - (restaurant_name, phone_number) 복합 UNIQUE  ← 엔티티 @Unique(['restaurantName','phoneNumber'])
+--  - address/phone_number/business_hours: NOT NULL (엔티티 @Column()과 일치)
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS restaurant (
   id               INT AUTO_INCREMENT PRIMARY KEY,
   restaurant_name  VARCHAR(200) NOT NULL,
-  address          VARCHAR(255),
-  phone_number     VARCHAR(30),
-  business_hours   VARCHAR(50),
-  delivery_fee     INT DEFAULT 0,
+  address          VARCHAR(255) NOT NULL,
+  phone_number     VARCHAR(30)  NOT NULL,
+  business_hours   VARCHAR(50)  NOT NULL,
+  delivery_fee     INT          NOT NULL DEFAULT 0,
   image_url        VARCHAR(512),
-  created_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  created_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_restaurant_name_phone (restaurant_name, phone_number)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ─────────────────────────────────────────────────────────────
--- food_item
--- (ManyToOne: restaurant)
+-- food_item (FoodItem 엔티티)
+--  - (restaurant_id, item_name) 복합 UNIQUE
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS food_item (
   id               INT AUTO_INCREMENT PRIMARY KEY,
@@ -41,14 +49,15 @@ CREATE TABLE IF NOT EXISTS food_item (
   image_url        VARCHAR(512),
   created_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   INDEX idx_food_item_restaurant_id (restaurant_id),
+  UNIQUE KEY uq_food_item_restaurant_name (restaurant_id, item_name),
   CONSTRAINT fk_food_item__restaurant
     FOREIGN KEY (restaurant_id) REFERENCES restaurant(id)
     ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ─────────────────────────────────────────────────────────────
--- food_fare_room
--- (ManyToOne: user(creator_user), restaurant)
+-- food_fare_room (FoodFareRoom 엔티티)
+--  - (creator_user_id, restaurant_id, deadline) 복합 UNIQUE
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS food_fare_room (
   id                INT AUTO_INCREMENT PRIMARY KEY,
@@ -59,6 +68,7 @@ CREATE TABLE IF NOT EXISTS food_fare_room (
   created_at        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   INDEX idx_room_creator_user_id (creator_user_id),
   INDEX idx_room_restaurant_id   (restaurant_id),
+  UNIQUE KEY uq_room_creator_rest_deadline (creator_user_id, restaurant_id, deadline),
   CONSTRAINT fk_room__creator_user
     FOREIGN KEY (creator_user_id) REFERENCES `user`(id)
     ON DELETE CASCADE ON UPDATE CASCADE,
@@ -68,8 +78,7 @@ CREATE TABLE IF NOT EXISTS food_fare_room (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ─────────────────────────────────────────────────────────────
--- food_result
--- (ManyToOne: food_fare_room)
+-- food_result (FoodResult 엔티티)
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS food_result (
   id                 INT AUTO_INCREMENT PRIMARY KEY,
@@ -84,8 +93,9 @@ CREATE TABLE IF NOT EXISTS food_result (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ─────────────────────────────────────────────────────────────
--- food_join_user
--- (ManyToOne: user, food_fare_room)
+-- food_join_user (FoodJoinUser 엔티티)
+--  - (user_id, food_fare_room_id) 복합 UNIQUE
+--  - delivery_confirmation: TINYINT(1) 기본 0
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS food_join_user (
   id                    INT AUTO_INCREMENT PRIMARY KEY,
@@ -105,8 +115,8 @@ CREATE TABLE IF NOT EXISTS food_join_user (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ─────────────────────────────────────────────────────────────
--- food_order
--- (ManyToOne: food_item, food_join_user)
+-- food_order (FoodOrder 엔티티)
+--  - (food_join_user_id, food_item_id) 복합 UNIQUE
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS food_order (
   id                 INT AUTO_INCREMENT PRIMARY KEY,
@@ -116,6 +126,7 @@ CREATE TABLE IF NOT EXISTS food_order (
   created_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   INDEX idx_order_item_id (food_item_id),
   INDEX idx_order_join_user_id (food_join_user_id),
+  UNIQUE KEY uq_order_joinuser_item (food_join_user_id, food_item_id),
   CONSTRAINT fk_order__item
     FOREIGN KEY (food_item_id) REFERENCES food_item(id)
     ON DELETE CASCADE ON UPDATE CASCADE,

--- a/mysql-init/01_seed.sql
+++ b/mysql-init/01_seed.sql
@@ -1,11 +1,11 @@
 USE `db`;
 
--- User 더미데이터
+-- User 더미데이터 (student_number: varchar(7) → 문자열로)
 INSERT INTO `user` (id, email, name, student_number, password, total_discount)
 VALUES
-  (1, 'alice@example.com',   'Alice',   20231234, '$2b$10$TB50LABUw2LOQFJTndZUz.zOEeibf2sH/d9pKJF/Yuy4Qg2aOZhoq', 0), -- abc123
-  (2, 'bob@example.com',     'Bob',     20235678, '$2b$10$/IazOXbqK7yl4g56uVGvFuoGV6syQ9hf8/mND/QImRTlPHTRzwDKa', 0), -- cdf456
-  (3, 'charlie@example.com', 'Charlie', 20239876, '$2b$10$gX5b9py8OAQDoq2pUOioiu2oHmFv00OZ0xYHbntkL4Tt6518M2.xO', 0); -- cdf123
+  (1, 'alice@example.com',   'Alice',   '2023123', '$2b$10$TB50LABUw2LOQFJTndZUz.zOEeibf2sH/d9pKJF/Yuy4Qg2aOZhoq', 0), -- abc123
+  (2, 'bob@example.com',     'Bob',     '2023567', '$2b$10$/IazOXbqK7yl4g56uVGvFuoGV6syQ9hf8/mND/QImRTlPHTRzwDKa', 0), -- cdf456
+  (3, 'charlie@example.com', 'Charlie', '2023987', '$2b$10$gX5b9py8OAQDoq2pUOioiu2oHmFv00OZ0xYHbntkL4Tt6518M2.xO', 0); -- cdf123
 
 -- Restaurant 더미데이터
 INSERT INTO restaurant (id, restaurant_name, address, phone_number, business_hours, delivery_fee, image_url)
@@ -34,15 +34,15 @@ VALUES
   (1, 1, 0, '주문 대기중'),
   (2, 2, 0, '결제 준비중');
 
--- FoodJoinUser 더미데이터
+-- FoodJoinUser 더미데이터 (delivery_confirmation: string → '0'로)
 INSERT INTO food_join_user (id, user_id, delivery_confirmation, food_fare_room_id)
 VALUES
-  (1, 1, 0, 1), -- Alice 참여
-  (2, 2, 0, 1), -- Bob 참여
-  (3, 2, 0, 2), -- Bob 참여
-  (4, 3, 0, 2); -- Charlie 참여
+  (1, 1, '0', 1), -- Alice 참여
+  (2, 2, '0', 1), -- Bob 참여
+  (3, 2, '0', 2), -- Bob 참여
+  (4, 3, '0', 2); -- Charlie 참여
 
--- FoodOrder 더미데이터
+-- FoodOrder 더미데이터 (변경 없음)
 INSERT INTO food_order (id, food_item_id, quantity, food_join_user_id)
 VALUES
   (1, 1, 1, 1), -- Alice: Pepperoni Pizza


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

- 주문 방의 진행 상태 관리(진행 시작), 참여 멤버의 메뉴 선택/주문 조회, 배달 확인 등 핵심 플로우가 흩어져 있어 사용자가 실제로 주문을 진행하기 어려웠습니다.
- DB 스키마와 엔티티/DTO의 제약(UNIQUE/NOT NULL, 타입)이 일치하지 않아 런타임 오류 및 데이터 무결성 문제가 발생할 수 있었습니다.
## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

1) DB 스키마 반영 및 엔티티 정렬
- mysql-init/00_schema.sql 갱신: 문자셋/콜레이션, 인덱스, FK, 복합 UNIQUE 정리.
- restaurant (restaurant_name, phone_number) UNIQUE
- food_item (restaurant_id, item_name) UNIQUE
- food_fare_room (creator_user_id, restaurant_id, deadline) UNIQUE
- food_join_user (user_id, food_fare_room_id) UNIQUE
- food_order (food_join_user_id, food_item_id) UNIQUE
- 엔티티를 스키마와 정렬(컬럼/관계/제약).
- 시드 데이터 업데이트.

2) 진행 상태 업데이트(Leader)
- FoodResult.progress를 1로 설정하는 서비스/엔드포인트 추가
- 방 존재/권한/상태 검증 포함
- 일관된 응답 포맷 { message, data }

3) 메뉴 선택(주문 생성, Member)
- 참여 중인 방에서 메뉴 선택(주문 생성)
- DTO: CreateFoodOrderDto (foodItemId, quantity 모두 1 이상)
- 검증: 참여 여부, 마감 전인지, 방 레스토랑과 메뉴 레스토랑 일치 여부
- food_order의 (food_join_user_id, food_item_id) UNIQUE 제약에 맞춰 중복 시 409(Conflict) 유도
→ 수량 변경은 PATCH를 사용(별도 엔드포인트)

4) 나의 참여 방/주문 조회(Member)
- 내가 참여 중인 방 목록 조회
- 특정 방에서의 내 주문 내역 조회

5) DTO/검증 강화
- CreateFoodOrderDto, CreateMyOrdersDto에 정수/최소값/중첩 검증 추가

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

- 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

- 없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

-

## 📚 관련된 Issue나 Notion, 문서

-

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
