### PR TITLE
✨ feat : Store refresh token on login and enable automatic accessToken renewal

### DIFF
--- a/frontend/src/app/(authPages)/components/LoginForm.tsx
+++ b/frontend/src/app/(authPages)/components/LoginForm.tsx
@@ -21,23 +21,28 @@ export default function LoginForm() {
   const { register, handleSubmit, formState: { errors } } = useForm<LoginFormInputs>();
 
   const onSubmit = async (data: LoginFormInputs) => {
-
     try {
       setServerError(false);
       setLoading(true);
-      const response = await Fetch("/auth/login", {
+
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
       });
-      if (response.ok && response.data?.accessToken) {
-          localStorage.setItem("jwtToken", response.data.accessToken);
-          await router.push("/");
-        } else {
-          setServerError(true);
-        }
-      } catch (error) {
-        // 요청 실패는 전부 여기서 처리
+
+      const responseData = await res.json();
+      const refreshToken = res.headers.get("refresh-token");
+
+      if (res.ok && responseData.accessToken) {
+        localStorage.setItem("jwtToken", responseData.accessToken);
+        if (refreshToken) localStorage.setItem("refreshToken", refreshToken); // 리프레쉬 토큰도 로컬스토리지에 저장
+        await router.push("/");
+      } else {
         setServerError(true);
+      }
+    } catch (error) {
+      setServerError(true);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/app/user/components/PartyHistory.tsx
+++ b/frontend/src/app/user/components/PartyHistory.tsx
@@ -15,7 +15,6 @@ export default function PartyHistory() {
 
   useEffect(() => {
     const token = localStorage.getItem("jwtToken");
-    console.log("디코딩한 JWT:", decodeJWT(token));
     if (token) {
       const decoded = decodeJWT(token);
       if (decoded) {

--- a/frontend/src/common/customFetch.ts
+++ b/frontend/src/common/customFetch.ts
@@ -1,83 +1,120 @@
 'use client';
 
 const useCustomFetch = () => {
-  
-  const customFetch = async (endpoint: string, options: RequestInit = {}) => {
+  const customFetch = async (endpoint: string, options: RequestInit = {}, retry = true) => {
+    // 엔드포인트, 옵션, 리트라이 = 기본값 트루
+
     const BASE_URL = process.env.NEXT_PUBLIC_API_URL as string;
-
-    let token = typeof window !== "undefined" ? localStorage.getItem("jwtToken") : null; 
-
-    const publicEndpoints = ["/auth/login", "/user/signup", "/auth/refresh"]; // 하위 url에는 영향을 미치지 않도록 배열로 정확히 일치하느 값만 처리 하도록 관리
+    const publicEndpoints = ["/auth/login", "/user/signup", "/auth/refresh"];
     const isPublicEndpoint = publicEndpoints.includes(endpoint);
 
-    // 토큰 만료 5분 전 체크
-    const isTokenExpiring = (token: string, minutesBefore = 5) => {
+    // 클라이언트에서만 token 가져오기
+    if (typeof window === "undefined") {
+      return { ok: false, status: 500, message: "SSR에서는 사용 불가", data: null };
+    }
+
+    // 1. 로컬 스토리지에서 JWT와 Refresh Token 가져오기
+    let token = localStorage.getItem("jwtToken");
+    let refreshToken = localStorage.getItem("refreshToken");
+
+    // accessToken 만료 몇 분 전 체크 함수
+    // t: JWT 토큰 문자열 (accessToken)
+    const isTokenExpiring = (t: string, minutesBefore = 5) => {
       try {
-        const payload = JSON.parse(atob(token.split(".")[1])); //header.payload
-        const expiry = payload.exp * 1000; //1초로 만들어주기
-        return expiry - Date.now() < minutesBefore * 60 * 1000;
+        const payload = JSON.parse(atob(t.split(".")[1])); // payload 부분 디코딩
+        return payload.exp * 1000 - Date.now() < minutesBefore * 60 * 1000; // 설정한 minutesBefore보다 남은 시간이 적으면 true
       } catch {
-        return true;
+        return true; // 토큰이 만료 되었으면 true
       }
     };
 
-    // 만료 전이면 리프레시 토큰으로 갱신
-    if (token && isTokenExpiring(token, 5)) {
-      try {
-        const refreshRes = await fetch(`${BASE_URL}/auth/refresh`, {
-          method: "POST",
-          // credentials: "include", // cors 오류로 주석처리
-        });
-        const refreshData = await refreshRes.json();
-        if (refreshRes.ok && refreshData.accessToken) {
-          const newAccessToken = refreshData.accessToken;
-          const newRefreshToken = refreshRes.headers.get("refresh-token"); //헤더에서 꺼냄
-          localStorage.setItem("jwtToken", newAccessToken);
+    // 2. accessToken 없거나 만료 5분 전이면 refresh 토큰으로 갱신 시도
+    const tryRefresh = async () => {
+      if (!refreshToken) return false;
 
-          // refresh token도 따로 저장
-          if (newRefreshToken) {
-            localStorage.setItem("refreshToken", newRefreshToken);
-          }
-          token = newAccessToken; 
-        } else {
-          localStorage.removeItem("jwtToken");
-          throw new Error("세션이 만료되었습니다. 다시 로그인 해주세요.");
+      try {
+        const res = await fetch(`${BASE_URL}/auth/refresh`, {
+          method: "POST",
+          headers: { 
+            "Content-Type": "application/json",
+            "refresh-token": refreshToken,
+          },
+        });
+
+        if (!res.ok) return false;
+
+        const data = await res.json();
+        const newAccessToken = data.accessToken;
+        const newRefreshToken = res.headers.get("refresh-token");
+
+        if (!newAccessToken) return false;
+
+        // refresh 성공 → 새 accessToken 및 refreshToken 저장
+        localStorage.setItem("jwtToken", newAccessToken);
+        token = newAccessToken;
+
+        if (newRefreshToken) {
+          localStorage.setItem("refreshToken", newRefreshToken);
+          refreshToken = newRefreshToken;
         }
-        
+
+        return true;
       } catch {
-        // 자동 로그아웃 처리 - 만료시간 될 때 까지 프론트에서 아무런 요청 X 일 경우(사용자의 움직임이 X) 
+        return false;
+      }
+    };
+
+    // accessToken 없거나 만료 시 refresh 시도
+    if (!token || isTokenExpiring(token, 5)) {
+      const refreshed = await tryRefresh();
+      if (!refreshed && !isPublicEndpoint) {
         localStorage.removeItem("jwtToken");
+        localStorage.removeItem("refreshToken");
         alert("세션이 만료되었습니다. 다시 로그인해주세요.");
-        window.location.href = ("/login");
-        return {
-          ok: false,
-          status: 401,
-          message: "세션 만료",
-          data: null,
-        };
+        window.location.href = "/login";
+        return { ok: false, status: 401, message: "세션 만료", data: null };
       }
     }
 
-
-    const defaultOptions: RequestInit = {
-      headers: {
-        "Content-Type": "application/json",
-        ...(!isPublicEndpoint && token
-          ? { Authorization: `Bearer ${token}` }
-          : {}),
-      },
+    // 3. API 요청 시 Authorization 헤더에 accessToken 추가(isPublicEndpoint 경로가 아닐 경우에)
+    const mergedHeaders = {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+      ...(!isPublicEndpoint && token ? { Authorization: `Bearer ${token}` } : {}),
     };
+    const mergedOptions = { ...options, headers: mergedHeaders };
 
-    const mergedOptions = { ...defaultOptions, ...options };
-    const res = await fetch(`${BASE_URL}${endpoint}`, mergedOptions);
-    const data = await res.json();
+    try {
+      const res = await fetch(`${BASE_URL}${endpoint}`, mergedOptions);
+      const data = await res.json();
 
-    return {
-      ok: res.ok,
-      status: res.status,
-      message: data.message,
-      data: data.data || data,
-    };
+      // 4. 401 응답 시 retry 플래그 확인 후 refresh 토큰으로 재시도
+      if (res.status === 401 && retry && !isPublicEndpoint) {
+        // retry가 true일 때만 한 번 재시도
+        const refreshed = await tryRefresh();
+        if (refreshed) {
+          return customFetch(endpoint, options, false); // refresh 재 시도 시, retry를 false 로 호출 해 재귀호출 무한루프 X
+        } else {
+          localStorage.removeItem("jwtToken");
+          localStorage.removeItem("refreshToken");
+          alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+          window.location.href = "/login";
+          return { ok: false, status: 401, message: "세션 만료", data: null };
+        }
+      }
+
+      // 5. 최종 결과를 {ok, status, message, data} 형태로 리턴
+      return { 
+        ok: res.ok, 
+        status: res.status, 
+        message: data.message || "", data: data.data || data };
+    } catch (err) {
+      return { 
+        ok: false, 
+        status: 500, 
+        message: err instanceof Error ? err.message : "알 수 없는 에러", 
+        data: null };
+    }
   };
 
   return customFetch;
@@ -85,10 +122,11 @@ const useCustomFetch = () => {
 
 export default useCustomFetch;
 
-// 전체 흐름 정리 
-// 	1.	로컬 스토리지에서 JWT 가져오기
-// 	2.	만료 5분 전 체크 후 자동 갱신 (Refresh API 호출)
-// 	- refresh 토큰 사용 성공 → 새 엑세스 토큰 및 리프레쉬 토큰 저장
-// 	- 실패 → 로컬 토큰 삭제 + /login으로 강제 이동 + alert로 로그인 만료 표시
-// 	3.	API 요청 보낼 때 Authorization 헤더 추가
-// 	4.	응답을 {ok, status, message, data} 형태로 리턴
+// 전체 흐름 정리
+// 1. 로컬 스토리지에서 JWT와 Refresh Token 가져오기
+// 2. accessToken 없거나 만료 5분 전이면 refresh 토큰으로 갱신 시도
+//    - refresh 성공 → 새 accessToken 및 refreshToken 저장
+//    - refresh 실패 → 로그아웃 처리 + /login으로 이동 + alert 표시
+// 3. API 요청 시 Authorization 헤더에 accessToken 추가
+// 4. 401 응답 시 retry 플래그 확인 후 refresh 토큰으로 재시도 - false로 설정하면 재시도하지 않음 → 무한 루프 방지
+// 5. 최종 결과를 {ok, status, message, data} 형태로 리턴


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

> 구현한 기능이나 해결한 과제, PR을 열게 된 계기나 목적을 리뷰어가 이해하기 쉽게 작성해주세요.
> 백로그 링크, 다이어그램, Figma 등의 관련 문서를 첨부하면 더 좋습니다.

- 로그인 폼의 로그인 후 refresh 토큰 저장 및 커스텀 훅의 accessToken 자동 갱신 기능을 구현 했습니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.

- 로그인 시 서버에서 받은 refresh 토큰을 localStorage에 저장하도록 수정
- useCustomFetch에서 accessToken 만료 시 refresh 토큰으로 자동 갱신
- 401 발생 시 한 번만 재시도하도록 retry 플래그 적용(무한 재귀호출 방지)
- 불필요하게 복잡했던 기존 코드 단순화

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> 없으면 "없음"이라고 작성해주세요.

- frontend/src/app/user/components/PartyHistory.tsx 의 테스트용 불필요한 콘솔 로그 삭제

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

> 개발 과정에서 다른 사람의 의견이 궁금하거나, 크로스 체크가 필요하다고 느낀 코드가 있으면 알려주세요.

-

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 작성해주세요.

-

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

-

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
