### PR TITLE
✨ feat : Redirect users based on delivery progress in /delivery page

### DIFF
--- a/frontend/src/app/delivery/page.tsx
+++ b/frontend/src/app/delivery/page.tsx
@@ -1,9 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
 import RoomListDiv from "./components/RoomListDiv";
 import Title from "../components/Title";
 import PlusButton from "./components/PlusButton";
 import BottomNavLayout from "../components/BottomNavLayout";
+import useCustomFetch from "@/common/customFetch";
 
-export default async function Home() {
+export default function Home() {
+  const router = useRouter();
+  const apiFetch = useCustomFetch();
+  const [progress, setProgress] = useState();
+
+  useEffect(() => {
+    const roomId = localStorage.getItem("currentRoomId");
+    const fetchProgress = async () => { 
+      if (!roomId) return;
+      try {
+        const res = await apiFetch(`/restaurant/progress/${roomId}`, {method: 'GET'})
+        if(res.ok) {
+          setProgress(res.data)
+        }
+      } catch(error) {
+        if(error instanceof Error) console.log(error.message);
+      }
+    };
+
+    fetchProgress();
+  }, []);
+
+  useEffect(() => {
+    const roomId = localStorage.getItem("currentRoomId");
+    const role = localStorage.getItem("currentRole"); 
+    if (!roomId || !role || !progress) return;
+
+      if (progress !== "3" && progress !== "2") { // 2(주문완료) 혹은 3(파티 해산)이 되었으면 더이상 강제 라우팅 X
+        router.replace(`/delivery/${role}/${roomId}`);
+      }
+  }, [progress, router]);
 
   return (
     <div className="flex flex-col items-center w-full h-full overflow-auto pt-0 mb-20">


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

> 구현한 기능이나 해결한 과제, PR을 열게 된 계기나 목적을 리뷰어가 이해하기 쉽게 작성해주세요.
> 백로그 링크, 다이어그램, Figma 등의 관련 문서를 첨부하면 더 좋습니다.

- 진행중인 파티에 가입 되어있는 유저가 /delivery 접속 시 해당 파티 페이지로 리다이렉트하는 기능을 구현했습니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.

- 파티 생성(리더) 혹은 참여(멤버) 시 로컬 스토리지에 저장된 currentRole 과 currentRoomId 를 사용해 참여 중 파티 페이지로 리다이렉트
  - api 요청을 통해 해당 방의 progress 를 받아 와 파티가 종료(혹은 해산) 되었을 경우(progress 2 || 3) if 문에 안걸리게 처리

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> 없으면 "없음"이라고 작성해주세요.

- 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

> 개발 과정에서 다른 사람의 의견이 궁금하거나, 크로스 체크가 필요하다고 느낀 코드가 있으면 알려주세요.

-

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 작성해주세요.

-

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

-

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
