### PR TITLE
✨ feat(member): add user bank account info to member menu response

### DIFF
--- a/backend/src/restaurant/member/Type/food-room-member-response.type.ts
+++ b/backend/src/restaurant/member/Type/food-room-member-response.type.ts
@@ -15,4 +15,9 @@ export class FoodRoomMemberResponseType {
   memberCount: number;
   @Type(() => MyOrderItemType)
   myOrderItems: MyOrderItemType[];
+  primaryBankAccount: {
+    id: number;
+    bankName: string;
+    accountNumber: string;
+  };
 }

--- a/backend/src/restaurant/member/member.service.ts
+++ b/backend/src/restaurant/member/member.service.ts
@@ -42,11 +42,16 @@ export class MemberService {
             foodFareRoom: { id: roomId },
             user: { id: userId }
         },
-        relations: ['user', 'foodFareRoom', 'foodFareRoom.creatorUser', 'foodFareRoom.restaurant', 'foodFareRoom.foodJoinUsers', 'foodOrders', 'foodOrders.foodItem']
+        relations: ['user', 'user.userBankAccounts', 'foodFareRoom', 'foodFareRoom.creatorUser', 'foodFareRoom.restaurant', 'foodFareRoom.foodJoinUsers', 'foodOrders', 'foodOrders.foodItem']
     })
     
     if (!foodRoomMember) {
       throw new NotFoundException(`해당 방에 참여한 기록이 없습니다. userId=${userId}, roomId=${roomId}`);
+    }
+
+    const primary = foodRoomMember.user.userBankAccounts.find(account => account.isPrimary);
+    if (!primary) {
+      throw new NotFoundException('해당 사용자의 주계좌가 설정되어 있지 않습니다.');
     }
 
     return {
@@ -61,7 +66,12 @@ export class MemberService {
             itemName: order.foodItem.itemName,
             quantity: order.quantity,
             price: order.foodItem.price
-          }))
+          })),
+          primaryBankAccount: {
+          id: primary.id,
+          bankName: primary.bankName,
+          accountNumber: primary.accountNumber,
+        },
     }
     }
 

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -1,6 +1,7 @@
 import { FoodFareRoom } from "src/restaurant/entities/food-fare-room.entity";
 import { FoodJoinUser } from "src/restaurant/entities/food-join-user.entity";
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { UserBankAccount } from "./userBankAccount.entity";
 
 @Entity()
 export class User {
@@ -27,6 +28,9 @@ export class User {
 
     @OneToMany(() => FoodJoinUser, (foodJoinUser) => foodJoinUser.user)
     foodJoinUsers: FoodJoinUser[];
+
+    @OneToMany(() => UserBankAccount, (bankAccount) => bankAccount.user)
+    userBankAccounts: UserBankAccount[];
 
     @Column({ select: false, nullable: true })
     refreshTokenHash?: string;

--- a/backend/src/user/entities/userBankAccount.entity.ts
+++ b/backend/src/user/entities/userBankAccount.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity()
+export class UserBankAccount {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, (user) => user.userBankAccounts, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column({ type: 'varchar', length: 50 })
+  bankName: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  accountNumber: string;
+
+  @Column({ type: 'boolean', default: false })
+  isPrimary: boolean;
+}

--- a/mysql-init/00_schema.sql
+++ b/mysql-init/00_schema.sql
@@ -134,3 +134,22 @@ CREATE TABLE IF NOT EXISTS food_order (
     FOREIGN KEY (food_join_user_id) REFERENCES food_join_user(id)
     ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- ─────────────────────────────────────────────────────────────
+-- user_bank_account (UserBankAccount 엔티티)
+--  - 한 유저는 여러 계좌를 가질 수 있음 (1:N)
+--  - (user_id, is_primary) 조합은 유저당 주계좌 1개만 허용하도록 UNIQUE
+--  - user 삭제 시 계좌도 함께 삭제 (ON DELETE CASCADE)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS user_bank_account (
+  id              INT AUTO_INCREMENT PRIMARY KEY,
+  user_id         INT NOT NULL,
+  bank_name       VARCHAR(50) NOT NULL,
+  account_number  VARCHAR(100) NOT NULL,
+  is_primary      BOOLEAN NOT NULL DEFAULT false,
+  created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_bank_user_id (user_id),
+  UNIQUE KEY uq_user_primary (user_id, is_primary),
+  CONSTRAINT fk_bank__user
+    FOREIGN KEY (user_id) REFERENCES `user`(id)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/mysql-init/01_seed.sql
+++ b/mysql-init/01_seed.sql
@@ -49,3 +49,10 @@ VALUES
   (2, 2, 2, 2), -- Bob: Cheese Pizza x2
   (3, 3, 1, 3), -- Bob: Sushi Set
   (4, 4, 1, 4); -- Charlie: Pork Belly BBQ
+
+-- UserBankAccount 더미데이터
+INSERT INTO user_bank_account (id, user_id, bank_name, account_number, is_primary)
+VALUES
+  (1, 1, 'Kookmin Bank',  '123-4567-8901', true),   -- Alice 주계좌
+  (2, 2, 'Shinhan Bank',  '987-6543-2100', true),   -- Bob 주계좌
+  (3, 3, 'Hana Bank',     '555-3333-2222', true);   -- Charlie 주계좌


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

- MemberService의 응답에 유저 계좌 정보를 함께 반환하도록 수정했습니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

- MemberService.getMemberMenu() 응답 필드에 bankName, accountNumber 추가
- FoodJoinUser → User → UserBankAccount 관계를 통해 계좌정보를 조회하도록 수정

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

- Swagger 응답 예시에 계좌정보 필드(bankName, accountNumber) 추가

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

- 없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

- 없음


## 📚 관련된 Issue나 Notion, 문서

- 없음


## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
