### PR TITLE
feat(user): sign up with primary bank account and Swagger docs

### DIFF
--- a/backend/src/user/dto/create-user-banc-account.dto.ts
+++ b/backend/src/user/dto/create-user-banc-account.dto.ts
@@ -1,0 +1,15 @@
+// dto/create-user-bank-account.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Length } from 'class-validator';
+
+export class CreateUserBankAccountDto {
+  @ApiProperty({ example: 'Kookmin Bank', description: '은행명' })
+  @IsString()
+  @IsNotEmpty()
+  bankName: string;
+
+  @ApiProperty({ example: '123-4567-8901', description: '계좌번호' })
+  @IsString()
+  @Length(5, 100)
+  accountNumber: string;
+}

--- a/backend/src/user/dto/create-user.dto.ts
+++ b/backend/src/user/dto/create-user.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsInt, IsNotEmpty, IsString, Length, Matches, MinLength } from "class-validator";
+import { IsEmail, IsInt, IsNotEmpty, IsString, Length, Matches, MinLength, ValidateNested } from "class-validator";
+import { CreateUserBankAccountDto } from "./create-user-banc-account.dto";
+import { Type } from "class-transformer";
 
 export class CreateUserDto {
   @ApiProperty({ type: String, description: '이메일 형식', required: true, example: 'aswq@example.com' })
@@ -20,4 +22,13 @@ export class CreateUserDto {
   @IsString()
   @MinLength(8)
   password: string;
+
+  @ApiProperty({
+    type: CreateUserBankAccountDto,
+    description: '사용자 계좌정보 (기본계좌 true 자동 설정)',
+    example: { bankName: 'Kookmin Bank', accountNumber: '123-4567-8901' },
+  })
+  @ValidateNested()
+  @Type(() => CreateUserBankAccountDto)
+  bankAccount: CreateUserBankAccountDto;
 }

--- a/backend/src/user/entities/userBankAccount.entity.ts
+++ b/backend/src/user/entities/userBankAccount.entity.ts
@@ -15,6 +15,6 @@ export class UserBankAccount {
   @Column({ type: 'varchar', length: 100 })
   accountNumber: string;
 
-  @Column({ type: 'boolean', default: false })
+  @Column({ type: 'boolean', default: true })
   isPrimary: boolean;
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -10,7 +10,7 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Post('signup')
-  @ApiOperation({ summary: '회원가입' })
+  @ApiOperation({ summary: '회원가입 (기본계좌 1개 포함 등록)' })
   @ApiCreatedResponse({
     description: '유저 회원가입 성공',
     schema: {
@@ -20,8 +20,13 @@ export class UserController {
           id: 4,
           email: 'aswq@example.com',
           name: 'aswq',
-          studentNumber: 2225446,
+          studentNumber: '2225446',
           totalDiscount: 0,
+          bankAccount: {
+            bankName: 'Kookmin Bank',
+            accountNumber: '123-4567-8901',
+            isPrimary: true,
+          },
         },
       },
     },

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
+import { UserBankAccount } from './entities/userBankAccount.entity';
 
 @Injectable()
 export class UserService {
@@ -15,15 +16,39 @@ export class UserService {
   async signUpUser(createUserDto: CreateUserDto) {
     const hashedPassword = await bcrypt.hash(createUserDto.password, 10);
 
-    const user = this.userRepo.create({
-      email: createUserDto.email,
-      name: createUserDto.name,
-      studentNumber: createUserDto.studentNumber,
-      password: hashedPassword,
-      totalDiscount:0,
-    })
-    const savedUser = await this.userRepo.save(user)
-    return savedUser;
+    const result = await this.userRepo.manager.transaction(async (manager) => {
+      const user = manager.create(User, {
+        email: createUserDto.email,
+        name: createUserDto.name,
+        studentNumber: createUserDto.studentNumber,
+        password: hashedPassword,
+        totalDiscount: 0,
+      });
+      const savedUser = await manager.save(user);
+
+      const bankRepo = manager.getRepository(UserBankAccount);
+      const bank = bankRepo.create({
+        user: savedUser,
+        bankName: createUserDto.bankAccount.bankName,
+        accountNumber: createUserDto.bankAccount.accountNumber,
+      });
+      const savedBank = await bankRepo.save(bank);
+
+      return {
+        id: savedUser.id,
+        email: savedUser.email,
+        name: savedUser.name,
+        studentNumber: savedUser.studentNumber,
+        totalDiscount: savedUser.totalDiscount,
+        bankAccount: {
+          bankName: savedBank.bankName,
+          accountNumber: savedBank.accountNumber,
+          isPrimary: savedBank.isPrimary,
+        },
+      };
+    });
+
+    return result;
   }
 
   async getMyInfo(userId: number) {

--- a/mysql-init/00_schema.sql
+++ b/mysql-init/00_schema.sql
@@ -145,7 +145,7 @@ CREATE TABLE IF NOT EXISTS user_bank_account (
   user_id         INT NOT NULL,
   bank_name       VARCHAR(50) NOT NULL,
   account_number  VARCHAR(100) NOT NULL,
-  is_primary      BOOLEAN NOT NULL DEFAULT false,
+  is_primary      BOOLEAN NOT NULL DEFAULT true,
   created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   INDEX idx_bank_user_id (user_id),
   UNIQUE KEY uq_user_primary (user_id, is_primary),


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

- 회원가입 시 계좌 1개(기본계좌) 도 함께 등록되도록 변경
- 유저 생성과 계좌 생성을 트랜잭션으로 처리해 데이터 정합성 보장

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

- CreateUserBankAccountDto 추가 및 CreateUserDto에 bankAccount 중첩 검증 적용
- UserService.signUpUser에 트랜잭션(userRepo.manager.transaction) 도입
- User 저장 → UserBankAccount 저장(기본 isPrimary=true)
- UserBankAccount 엔티티 기본값 isPrimary: true 설정
- Swagger 문서: POST /user/signup, GET /user/me 예시/설명 업데이트

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

- 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

- 없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

- 없음

## 📚 관련된 Issue나 Notion, 문서

- 없음
- 
## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
