### PR TITLE
feat: update member controller and service for room leaving feature

### DIFF
--- a/backend/src/restaurant/member/member.controller.ts
+++ b/backend/src/restaurant/member/member.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, HttpCode, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { MemberService } from './member.service';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { ApiBearerAuth, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
@@ -91,5 +91,18 @@ export class MemberController {
     return {
       message: `foodJoinUser ${id}번 방에서 delivery_confirmation 1로 변경`,
     };
+  }
+
+  @Delete('foodFareRoom/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '해당 방 나가기', description: 'jwt토큰 인증 후 자신이 참여한 방에서 나가기' })
+  @ApiParam({ name: 'id', type: Number, description: '방 ID', example: 2 })
+  @ApiOkResponse({
+    description: '삭제 성공 시 204 반환',
+  })
+  @HttpCode(204)
+  async leaveFoodFareRoom(@Param('id') roomId: string, @Req() req: Request): Promise<void> {
+    await this.memberService.leaveFoodFareRoom(+roomId, req.user.id);
   }
 }

--- a/backend/src/restaurant/member/member.service.ts
+++ b/backend/src/restaurant/member/member.service.ts
@@ -93,4 +93,20 @@ export class MemberService {
 
       await this.foodJoinUserRepo.save(foodJoinUser)
     }
+
+    async leaveFoodFareRoom(roomId: number, userId: number): Promise<void> {
+      const exists = await this.foodFareRoomRepo.exists({ 
+        where: { id: roomId } 
+      });
+      if (!exists) throw new NotFoundException(`roomId=${roomId} 방이 없습니다.`);
+
+      const result = await this.foodJoinUserRepo.delete({
+        foodFareRoom: { id: roomId },
+        user: { id: userId },
+      });
+
+      if (!result.affected || result.affected === 0) {
+        throw new NotFoundException(`해당 방에 참여 기록이 없습니다. userId=${userId}, roomId=${roomId}`);
+      }
+    }
 }


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

- 방에서 나갈때 관련 db 삭제하는 api가 없었음

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

- DELETE /restaurant/member/foodFareRoom/:id 엔드포인트 추가
- 방 나갈 때 FoodJoinUser 레코드 삭제 시, 연관된 FoodOrder가 onDelete: 'CASCADE' 설정으로 자동 삭제되도록 구현
- MemberService 내부 leaveFoodFareRoom() 메서드 구현 완료

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

- 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

- 없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

- 없음
- 
## 📚 관련된 Issue나 Notion, 문서

- 없음

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
